### PR TITLE
fix version requirement to use correct syntax

### DIFF
--- a/lib/Log/Tree.pm
+++ b/lib/Log/Tree.pm
@@ -15,7 +15,7 @@ use namespace::autoclean;
 use English qw( -no_match_vars );
 use Log::Dispatch;
 use Log::Dispatch::Screen;
-use Data::Tree '0.16';
+use Data::Tree 0.16;
 use IO::Interactive::Tiny qw();
 
 has 'dispatcher' => (


### PR DESCRIPTION
Version numbers on a use line need to be unquoted to be handled properly. When they are quoted, they are passed in import instead. Part versions of perl ignored these arguments, but future versions are intending to throw errors for arguments given to an undefined import method.